### PR TITLE
Added the isXHR helper method

### DIFF
--- a/modules/libs/helpers.js
+++ b/modules/libs/helpers.js
@@ -62,6 +62,19 @@ var Helpers = {
     }
     str = str.replace(/[^a-z0-9 -]/g, "").replace(/\s+/g, "-").replace(/-+/g, "-");
     return str;
+  },
+
+  // is the request an AJAX call?
+  // To recognize this, we unfortunately cannot rely on the
+  // X_REQUESTED_WITH header since some browsers (IE7) don't support it.
+  // So we're checking the "Accept" header of the request and see
+  // if it's asking for the "application/json" content-type.
+  isXHR: function(req, res) {
+    if (req.header.accepts('application/json')) {
+      return true;
+    } else {
+      return false;
+    }
   }
 };
 

--- a/modules/libs/helpers.js
+++ b/modules/libs/helpers.js
@@ -65,12 +65,8 @@ var Helpers = {
   },
 
   // is the request an AJAX call?
-  // To recognize this, we unfortunately cannot rely on the
-  // X_REQUESTED_WITH header since some browsers (IE7) don't support it.
-  // So we're checking the "Accept" header of the request and see
-  // if it's asking for the "application/json" content-type.
   isXHR: function(req, res) {
-    if (req.header.accepts('application/json')) {
+    if (req.header('HTTP_X_REQUESTED_WITH') === 'XMLHttpRequest') {
       return true;
     } else {
       return false;
@@ -79,3 +75,4 @@ var Helpers = {
 };
 
 module.exports = Helpers;
+


### PR DESCRIPTION
This method is often used when you want to decide whether to send JSON datas (answering an AJAX call) or just plain HTML.

This method is in the same line as `isPost`, `isGet`, or even `isDefined`.

I hesitated to add a method where the correct headers are set (you must invalidate cache or [IE will bite you if you don't](http://greenash.net.au/thoughts/2006/03/an-ie-ajax-gotcha-page-caching/)). This should probably be done later when a better architecture for these helper methods is built.
