### PR TITLE
Cleaned up core.js file

### DIFF
--- a/core.js
+++ b/core.js
@@ -2,13 +2,12 @@ require("./config");
 
 var path = require('path');
 
-require("ncore/modules/core")({
+require("ncore")({
     uri: __dirname,
     dependencyMapper: {
-        jsonUri: path.join(__dirname, "libs", "dependency.json"),
-        uri: __dirname
+        jsonUri: path.join(__dirname, "libs", "dependency.json")
     },
     moduleLoader: {
-      skip: /test|public|node_modules|bin/
+        skip: /test|public|node_modules|bin/
     }
 });

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "git://github.com/tbergeron/ThinAir.git"
   },
   "dependencies": {
-    "ncore": "2.2.1",
+    "ncore": "2.2.3",
     "handlebars": "1.0.5beta",
     "mongojs": "0.3.2",
     "pd": "0.6.3",


### PR DESCRIPTION
This is about it in terms of boilerplate removal.

If you stick to the convention of 
- core.js
- modules
  - dependency.json

Then you can have

`require("ncore")()`
